### PR TITLE
Use HEAD requests and User-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Feel free to tune and tweak the code. If you make it better or faster, please le
 
 You could certainly make it significantly faster by reducing the time that the script checks each URL:
 
-`response = requests.get(final_url, timeout=15)`
+`response = requests.head(final_url, headers=headers, timeout=15)`
 
 t.c.graves@sussex.ac.uk 
 

--- a/aspire_link_check_mis_jdbc.py
+++ b/aspire_link_check_mis_jdbc.py
@@ -6,6 +6,9 @@
 # 08/07/2021
 # Using the JDBC connection. (I found out  that my previous driver would cost £8k in licencing!
 
+# 03/02/2022
+# use head requests rather than get
+
 # Tim Graves. t.c.graves@sussex.ac.uk. University of Sussex Library
 
 import jaydebeapi as jay
@@ -49,6 +52,9 @@ curs = conn.cursor()
 curs.execute(cfg['sql'])
 results = curs.fetchall()
 
+# set request headers
+headers = { 'User-Agent', 'Aspire-Link-Checker'}
+
 ############
 		
 # Function to write out the results
@@ -85,7 +91,7 @@ for each_one in results:
             final_url = 'http' + temp_url
             #print(final_url)
             try:
-                response = requests.get(final_url, timeout=15)   # Original timeout 15
+                response = requests.head(final_url, headers=headers, timeout=15)   # Original timeout 15
                 status = response.status_code
             except:
                 status  = 408
@@ -100,7 +106,7 @@ for each_one in results:
     else: # Carry on and process the entries without duplicate URLs
 		
         try:
-            response = requests.get(the_url, timeout=15)   # Original timeout 15
+            response = requests.head(the_url, headers=headers, timeout=15)   # Original timeout 15
             status = response.status_code
         except:
             status  = 408

--- a/aspire_link_check_mis_windows.py
+++ b/aspire_link_check_mis_windows.py
@@ -73,7 +73,7 @@ for each_one in results:
             final_url = 'http' + temp_url
             
             try:
-                response = requests.head(final_url, timeout=15)   
+                response = requests.head(final_url, headers=headers, timeout=15)   
                 status = response.status_code
             except:
                 status  = 408
@@ -88,7 +88,7 @@ for each_one in results:
     else: # Carry on and process the entries without duplicate URLs
 		
         try:
-            response = requests.head(the_url, timeout=15)   
+            response = requests.head(the_url, headers=headers, timeout=15)   
             status = response.status_code
         except:
             status  = 408

--- a/aspire_link_check_mis_windows.py
+++ b/aspire_link_check_mis_windows.py
@@ -17,6 +17,9 @@ from csv import writer
 import requests
 import yaml
 
+# set request headers
+headers = { 'User-Agent', 'Aspire-Link-Checker'}
+
 # read configuration
 with open("config.yml", "r") as ymlfile:
     cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
@@ -70,7 +73,7 @@ for each_one in results:
             final_url = 'http' + temp_url
             
             try:
-                response = requests.get(final_url, timeout=15)   
+                response = requests.head(final_url, timeout=15)   
                 status = response.status_code
             except:
                 status  = 408
@@ -85,7 +88,7 @@ for each_one in results:
     else: # Carry on and process the entries without duplicate URLs
 		
         try:
-            response = requests.get(the_url, timeout=15)   
+            response = requests.head(the_url, timeout=15)   
             status = response.status_code
         except:
             status  = 408

--- a/aspire_link_checker.py
+++ b/aspire_link_checker.py
@@ -9,6 +9,9 @@ import requests
 import re
 from csv import writer 
 
+# set request headers
+headers = { 'User-Agent', 'Aspire-Link-Checker'}
+
 original_filename = 'all_list_items_2021_03_11.csv'
 
 # In a normal run, you shouldn't need to edit anything below this point
@@ -91,7 +94,7 @@ for line in fh:
             final_url = 'http' + temp_url
             #print(final_url)
             try:
-                response = requests.get(final_url, timeout=15)   # Original timeout 15
+                response = requests.head(final_url, headers=headers, timeout=15)   # Original timeout 15
                 status = response.status_code
             except:
                 status  = 408
@@ -107,7 +110,7 @@ for line in fh:
     else: # Carry on and process the entries without duplicate URLs
 		
         try:
-            response = requests.get(the_url, timeout=15)   # Original timeout 15
+            response = requests.head(the_url, headers=headers, timeout=15)   # Original timeout 15
             status = response.status_code
         except:
             status  = 408


### PR DESCRIPTION
After running the link checker for a couple of weeks we identified a problem with AustLII (the Australian legal repository)  throwing 404s for every request. Further investigation  identified that their automated tools had flagged the tool as a web scraper, hence the errors.

AustLII pointed out that the link checker uses a GET call but we don't need to, because all we care about is the response code, not the actual page content. They requested a change to use a HEAD request, and add a unique and identifiable `User-Agent` name instead of using the generic requests module name. This both avoids being miscategorised as a web scraping tool (since a HEAD request doesn't touch the body of the pages), and presents users of the tool as good web citizens by clearly identifying what is sending the request.

I've made these changes locally with success, but it seems that this is likely to be an issue with other publishers and the suggested changes were pretty sensible so I have put together a small PR for consideration.